### PR TITLE
Add requirement to host section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python {{ python_min }}
     - setuptools-git-versioning
     - pip
+    - setuptools
   run:
     - python >={{ python_min }}
     - jinja2


### PR DESCRIPTION
This PR is an addition to https://github.com/conda-forge/actinia-python-client-feedstock/pull/17

And includes the suggestion from above PR

```
I do have some suggestions for making it better though...

For recipe/meta.yaml:

ℹ️ No valid build backend found for Python recipe for package actinia-python-client using pip. Python recipes using pip need to explicitly specify a build backend in the host section. If your recipe has built with only pip in the host section in the past, you likely should add setuptools to the host section of your recipe.
```